### PR TITLE
ci: made release step depend on successful build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,19 +3,15 @@
 name: Release
 
 on:
-  push:
-    # Specifying branches is not really needed if the semantic-release configuration is correct.
-    # It should still work to run on all branches.
-    # feature branches shouldn't trigger a release
-    # prerelease branches should trigger a prerelease
-    # release branches should trigger a release
-    # But this check requires the action to run which is redundant for feature branches.
-    # Use this check so semantic-release doesn't need to run unnecessarily.
-    # Gives a cleaner action history and saves on minutes :)
-    branches:
-      - "rc"
-      - "main"
-      - "master"
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+    # Could possibly skip branches as an actual release will only be made if its warranted and
+    # on the correct branches anyway. But have the branches explicitly to keep the actions
+    # sections cleaner (otherwise it would still show a run release action, which won't do anything else
+    # but confirm that a release isn't needed).
+    # The release workflow could be a job in the build workflow instead, maybe cleaner?
+    branches: [rc, main, master] 
     
 jobs:
   release:


### PR DESCRIPTION
Previously the release step was triggered on push to prerelease and release branches.
This would make the build- and release workflow run in parallell.
Even if build failed, release would run intil finished.
Made release depend on build instead