### PR TITLE
ci: push helm charts to registry

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -4,12 +4,6 @@ name: "📦 Release"
 
 on: 
   workflow_call:
-    inputs:
-      container-registry:
-        type: string
-        required: false
-        default: ghcr.io
-        description: "The container registry to push released images to, should coincide with registry in releaserc config."
     secrets:
       release-gh-token:
         description: 'Github token used when running semantic release'
@@ -19,6 +13,12 @@ on:
         required: true
       helm-repository-password:
         description: 'Username if/when pushing helm charts'
+        required: true
+      container-registry-username:
+        description: 'Username if/when pushing build container'
+        required: true
+      container-registry-password:
+        description: 'Password if/when pushing build container'
         required: true
         
 
@@ -48,13 +48,6 @@ jobs:
     
     - run: npm ci
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ${{ inputs.container-registry }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Create release using semantic release
       run: npx semantic-release       
       env:
@@ -62,3 +55,5 @@ jobs:
         HUSKY: 0
         REGISTRY_USERNAME: ${{ secrets.helm-repository-username }}
         REGISTRY_PASSWORD: ${{ secrets.helm-repository-password }}
+        DOCKER_REGISTRY_USER: ${{ secrets.container-registry-username }}
+        DOCKER_REGISTRY_PASSWORD: ${{ secrets.container-registry-password }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,7 @@ jobs:
     uses: ./.github/workflows/_release.yml
     secrets:
       release-gh-token: ${{ secrets.PUBLIC_RELEASE_TOKEN }}
+      container-repository-username: ${{ secrets.PUBLIC_REGISTRY_USERNAME }}
+      container-repository-password: ${{ secrets.PUBLIC_REGISTRY_PASSWORD }}
       helm-repository-username: ${{ secrets.PUBLIC_REGISTRY_USERNAME }}
       helm-repository-password: ${{ secrets.PUBLIC_REGISTRY_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# Possible package helm charts
+**/*.tgz

--- a/.releaserc
+++ b/.releaserc
@@ -17,7 +17,7 @@
       }
     ],
     [
-      "semantic-release-helm",
+      "semantic-release-helm3",
       {
         "chartPath": "./helm/",
         "registry": "harbor.visegue.se/visegue-public"

--- a/.releaserc
+++ b/.releaserc
@@ -21,7 +21,7 @@
       "semantic-release-helm",
       {
         "chartPath": "./helm/",
-        "registry": "https://harbor.visegue.se/chartrepo/visegue-public"
+        "registry": "oci://harbor.visegue.se/visegue-public"
       }
     ],
     "@semantic-release/github",

--- a/.releaserc
+++ b/.releaserc
@@ -21,7 +21,7 @@
       "semantic-release-helm",
       {
         "chartPath": "./helm/",
-        "registry": "oci://harbor.visegue.se/visegue-public"
+        "registry": "harbor.visegue.se/visegue-public"
       }
     ],
     "@semantic-release/github",

--- a/.releaserc
+++ b/.releaserc
@@ -13,8 +13,7 @@
       "@codedependant/semantic-release-docker",
       {
         "dockerRegistry": "harbor.visegue.se",
-        "dockerProject": "visegue-public",
-        "dockerLogin": false
+        "dockerProject": "visegue-public"
       }
     ],
     [

--- a/.releaserc
+++ b/.releaserc
@@ -20,7 +20,8 @@
       "semantic-release-helm3",
       {
         "chartPath": "./helm/",
-        "registry": "harbor.visegue.se/visegue-public"
+        "registry": "https://harbor.visegue.se/chartrepo/visegue-public",
+        "isChartMuseum": true
       }
     ],
     "@semantic-release/github",

--- a/.releaserc
+++ b/.releaserc
@@ -17,10 +17,12 @@
         "dockerLogin": false
       }
     ],
-    "semantic-release-helm",
+    [
+      "semantic-release-helm",
       {
         "chartPath": "./helm/"
-      },
+      }
+    ],
     "@semantic-release/github",
     "@semantic-release/git"
   ],

--- a/.releaserc
+++ b/.releaserc
@@ -35,7 +35,7 @@
   "branches": [
     "main",
     {
-      "name": "rc",
+      "name": "next",
       "prerelease": true
     }
   ]

--- a/.releaserc
+++ b/.releaserc
@@ -24,7 +24,12 @@
       }
     ],
     "@semantic-release/github",
-    "@semantic-release/git"
+    [
+      "@semantic-release/git",
+      {
+        "assets": ['CHANGELOG.md', 'package.json', 'package-lock.json', 'helm/Chart.yaml', 'npm-shrinkwrap.json']
+      }
+    ]
   ],
   "branches": [
     "main",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.3-rc.3](https://github.com/Visegue/pipeline-lab/compare/v1.1.3-rc.2...v1.1.3-rc.3) (2022-04-24)
+
+
+### Bug Fixes
+
+* proper configuration key for semantic-release-helm3 ([0409f7f](https://github.com/Visegue/pipeline-lab/commit/0409f7f56554f5e082865be2a725fa4edbde0190)), closes [#25](https://github.com/Visegue/pipeline-lab/issues/25)
+
 ## [1.1.3-rc.2](https://github.com/Visegue/pipeline-lab/compare/v1.1.3-rc.1...v1.1.3-rc.2) (2022-04-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.1.3-next.1](https://github.com/Visegue/pipeline-lab/compare/v1.1.2...v1.1.3-next.1) (2022-05-11)
+
+
+### Bug Fixes
+
+* changed chart registry path ([6981281](https://github.com/Visegue/pipeline-lab/commit/6981281e5b5fcf9f743ea5a320b4604db957dd43)), closes [#25](https://github.com/Visegue/pipeline-lab/issues/25)
+* faux commit to test releas ([a157f02](https://github.com/Visegue/pipeline-lab/commit/a157f02ca0f18e14e5bb5365e235bc67e6ce9bcb))
+* faxu commit to test release ([145118b](https://github.com/Visegue/pipeline-lab/commit/145118b97a9c841a018238747d119c55b5d2f508))
+* moved container push logic to the release file ([dc586cb](https://github.com/Visegue/pipeline-lab/commit/dc586cbb6d3484eb31547bffd977bafc77a52dc1)), closes [#25](https://github.com/Visegue/pipeline-lab/issues/25)
+* proper configuration key for semantic-release-helm3 ([0409f7f](https://github.com/Visegue/pipeline-lab/commit/0409f7f56554f5e082865be2a725fa4edbde0190)), closes [#25](https://github.com/Visegue/pipeline-lab/issues/25)
+* trying chart release registry without protocol ([cac18f8](https://github.com/Visegue/pipeline-lab/commit/cac18f85ff8914aced5cdeaf8d812008106aa331)), closes [#25](https://github.com/Visegue/pipeline-lab/issues/25)
+
 ## [1.1.3-rc.4](https://github.com/Visegue/pipeline-lab/compare/v1.1.3-rc.3...v1.1.3-rc.4) (2022-04-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.1.1-rc.1](https://github.com/Visegue/pipeline-lab/compare/v1.1.0...v1.1.1-rc.1) (2022-04-10)
+
+
+### Bug Fixes
+
+* added helm chart to release push back ([c693d0f](https://github.com/Visegue/pipeline-lab/commit/c693d0fdc3bde47e40831b4a9607205bd24c3a39))
 
 # [1.1.0](https://github.com/Visegue/pipeline-lab/compare/v1.0.2...v1.1.0) (2022-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.1.0-rc.3](https://github.com/Visegue/pipeline-lab/compare/v1.1.0-rc.2...v1.1.0-rc.3) (2022-04-10)
+
+
+### Bug Fixes
+
+* added helm chart to release push back ([c693d0f](https://github.com/Visegue/pipeline-lab/commit/c693d0fdc3bde47e40831b4a9607205bd24c3a39))
+
 # [1.1.0-rc.2](https://github.com/Visegue/pipeline-lab/compare/v1.1.0-rc.1...v1.1.0-rc.2) (2022-04-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [1.1.0-rc.2](https://github.com/Visegue/pipeline-lab/compare/v1.1.0-rc.1...v1.1.0-rc.2) (2022-04-07)
+
+
+### Bug Fixes
+
+* added helm to the release config ([e757173](https://github.com/Visegue/pipeline-lab/commit/e75717316304fb9a2684eac6bc7f0229f03baf43)), closes [#15](https://github.com/Visegue/pipeline-lab/issues/15)
+* added missing semantic-release-helm ([9ce3d08](https://github.com/Visegue/pipeline-lab/commit/9ce3d08d6b0b16e7df5774549ce0006f064ba9a3)), closes [#15](https://github.com/Visegue/pipeline-lab/issues/15)
+* proper formatting of releaserc file ([e2b18bb](https://github.com/Visegue/pipeline-lab/commit/e2b18bb782d356f88dbefa4c619042bd6edd5607)), closes [#16](https://github.com/Visegue/pipeline-lab/issues/16)
+* proper path to helm chart ([2d04c5d](https://github.com/Visegue/pipeline-lab/commit/2d04c5d5f0a192be742caf1be7edfb2bb1f327ee)), closes [#16](https://github.com/Visegue/pipeline-lab/issues/16)
+
 # [1.1.0-rc.1](https://github.com/Visegue/pipeline-lab/compare/v1.0.2...v1.1.0-rc.1) (2022-04-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.3-rc.4](https://github.com/Visegue/pipeline-lab/compare/v1.1.3-rc.3...v1.1.3-rc.4) (2022-04-24)
+
+
+### Bug Fixes
+
+* faux commit to test releas ([a157f02](https://github.com/Visegue/pipeline-lab/commit/a157f02ca0f18e14e5bb5365e235bc67e6ce9bcb))
+
 ## [1.1.3-rc.3](https://github.com/Visegue/pipeline-lab/compare/v1.1.3-rc.2...v1.1.3-rc.3) (2022-04-24)
 
 

--- a/faux.txt
+++ b/faux.txt
@@ -1,1 +1,1 @@
-test8
+test9

--- a/faux.txt
+++ b/faux.txt
@@ -1,1 +1,1 @@
-test7
+test8

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pipeline-lab
 description: A helm chart for deploying pipeline-lab to kubernetes
 type: application
-version: 1.1.3-rc.3
-appVersion: 1.1.3-rc.3
+version: 1.1.3-rc.4
+appVersion: 1.1.3-rc.4

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pipeline-lab
 description: A helm chart for deploying pipeline-lab to kubernetes
 type: application
-version: 0.1.5
-appVersion: 1.1.3-rc.2
+version: 1.1.3-rc.3
+appVersion: 1.1.3-rc.3

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pipeline-lab
 description: A helm chart for deploying pipeline-lab to kubernetes
 type: application
-version: 0.1.1
-appVersion: 1.1.0-rc.3
+version: 0.1.2
+appVersion: 1.1.1-rc.1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pipeline-lab
 description: A helm chart for deploying pipeline-lab to kubernetes
 type: application
-version: 1.1.3-rc.4
-appVersion: 1.1.3-rc.4
+version: 1.1.3-next.1
+appVersion: 1.1.3-next.1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,24 +1,6 @@
 apiVersion: v2
 name: pipeline-lab
 description: A helm chart for deploying pipeline-lab to kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "1.0.2"
+version: 0.1.1
+appVersion: 1.1.0-rc.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.3-rc.4",
+  "version": "1.1.3-next.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pipeline-lab",
-      "version": "1.1.3-rc.4",
+      "version": "1.1.3-next.1",
       "dependencies": {
         "next": "12.1.0",
         "react": "17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.0-rc.3",
+  "version": "1.1.1-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pipeline-lab",
-      "version": "1.1.0-rc.3",
+      "version": "1.1.1-rc.1",
       "dependencies": {
         "next": "12.1.0",
         "react": "17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.3-rc.2",
+  "version": "1.1.3-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pipeline-lab",
-      "version": "1.1.3-rc.2",
+      "version": "1.1.3-rc.3",
       "dependencies": {
         "next": "12.1.0",
         "react": "17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pipeline-lab",
-      "version": "1.1.0-rc.1",
+      "version": "1.1.0-rc.2",
       "dependencies": {
         "next": "12.1.0",
         "react": "17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "node-mocks-http": "^1.11.0",
         "prettier": "2.5.1",
         "semantic-release": "^19.0.2",
-        "semantic-release-helm": "^2.1.0",
+        "semantic-release-helm3": "^2.3.2",
         "typescript": "4.5.5"
       }
     },
@@ -13299,10 +13299,10 @@
         "node": ">=16 || ^14.17"
       }
     },
-    "node_modules/semantic-release-helm": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semantic-release-helm/-/semantic-release-helm-2.1.0.tgz",
-      "integrity": "sha512-BvuxTXcnukdozfLXee2IXdHG1evNoB5cFAZ9xG6cnO6I8PPEkcYfeav7NGPCh2qDt8qP2rHPD0M9EuKbZ/SrNQ==",
+    "node_modules/semantic-release-helm3": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/semantic-release-helm3/-/semantic-release-helm3-2.3.2.tgz",
+      "integrity": "sha512-80cCPd63Q7bkVNpsWzDdce1K93/xV8N7Dkt5BBfUwQ8CjNmgIumuNKwzQaJZZAbOlDqYv10aZaozr/4UYv7n1g==",
       "dev": true,
       "dependencies": {
         "aggregate-error": "^3.1.0",
@@ -13312,13 +13312,13 @@
         "semver": "^7.3.4"
       }
     },
-    "node_modules/semantic-release-helm/node_modules/argparse": {
+    "node_modules/semantic-release-helm3/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/semantic-release-helm/node_modules/js-yaml": {
+    "node_modules/semantic-release-helm3/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
@@ -13330,28 +13330,19 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/semantic-release-helm/node_modules/lru-cache": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-      "integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/semantic-release-helm/node_modules/semver": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-      "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+    "node_modules/semantic-release-helm3/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dev": true,
       "dependencies": {
-        "lru-cache": "^7.4.0"
+        "lru-cache": "^6.0.0"
       },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
-        "node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+        "node": ">=10"
       }
     },
     "node_modules/semantic-release/node_modules/figures": {
@@ -24620,10 +24611,10 @@
         }
       }
     },
-    "semantic-release-helm": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semantic-release-helm/-/semantic-release-helm-2.1.0.tgz",
-      "integrity": "sha512-BvuxTXcnukdozfLXee2IXdHG1evNoB5cFAZ9xG6cnO6I8PPEkcYfeav7NGPCh2qDt8qP2rHPD0M9EuKbZ/SrNQ==",
+    "semantic-release-helm3": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/semantic-release-helm3/-/semantic-release-helm3-2.3.2.tgz",
+      "integrity": "sha512-80cCPd63Q7bkVNpsWzDdce1K93/xV8N7Dkt5BBfUwQ8CjNmgIumuNKwzQaJZZAbOlDqYv10aZaozr/4UYv7n1g==",
       "dev": true,
       "requires": {
         "aggregate-error": "^3.1.0",
@@ -24648,19 +24639,13 @@
             "argparse": "^2.0.1"
           }
         },
-        "lru-cache": {
-          "version": "7.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
-          "integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
-          "dev": true
-        },
         "semver": {
-          "version": "7.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-          "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
-            "lru-cache": "^7.4.0"
+            "lru-cache": "^6.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.0-rc.2",
+  "version": "1.1.0-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pipeline-lab",
-      "version": "1.1.0-rc.2",
+      "version": "1.1.0-rc.3",
       "dependencies": {
         "next": "12.1.0",
         "react": "17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.3-rc.3",
+  "version": "1.1.3-rc.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pipeline-lab",
-      "version": "1.1.3-rc.3",
+      "version": "1.1.3-rc.4",
       "dependencies": {
         "next": "12.1.0",
         "react": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.0-rc.3",
+  "version": "1.1.1-rc.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.0-rc.1",
+  "version": "1.1.0-rc.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.3-rc.3",
+  "version": "1.1.3-rc.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node-mocks-http": "^1.11.0",
     "prettier": "2.5.1",
     "semantic-release": "^19.0.2",
-    "semantic-release-helm": "^2.1.0",
+    "semantic-release-helm3": "^2.3.2",
     "typescript": "4.5.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.3-rc.2",
+  "version": "1.1.3-rc.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.3-rc.4",
+  "version": "1.1.3-next.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipeline-lab",
-  "version": "1.1.0-rc.2",
+  "version": "1.1.0-rc.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Should now properly push image and helm chart to specified registries in releaserc.

Refs: #25 